### PR TITLE
Add initial unit tests and CI pipeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: File a bug report
+labels: ["Type: Bug", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
+        sure you are using the latest version of the charm. If not, please switch to this image prior to 
+        posting your report to make sure it's not already solved.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: >
+        If applicable, add screenshots to help explain your problem. If applicable, add screenshots to 
+        help explain the problem you are facing.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: >
+        Please provide a step-by-step instruction of how to reproduce the behavior.
+      placeholder: |
+        1. `juju deploy ...`
+        2. `juju relate ...`
+        3. `juju status --relations`
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        We need to know a bit more about the context in which you run the charm.
+        - Are you running Juju locally, on lxd, in multipass or on some other platform?
+        - What track and channel you deployed the charm from (ie. `latest/edge` or similar).
+        - Version of any applicable components, like the juju snap, the model controller, lxd, microk8s, and/or multipass.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: >
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs 
+        at https://juju.is/docs/olm/juju-logs
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,8 +13,7 @@ body:
     attributes:
       label: Bug Description
       description: >
-        If applicable, add screenshots to help explain your problem. If applicable, add screenshots to 
-        help explain the problem you are facing.
+        Provide a description of the issue you are facing. If applicable, add screenshots to help explain the problem.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,8 +6,8 @@ body:
     attributes:
       value: >
         Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
-        sure you are using the latest version of the charm. If not, please switch to this image prior to 
-        posting your report to make sure it's not already solved.
+        sure you are using the latest version of the charm. If not, please switch to the lastest version of this charm
+        before posting your report to make sure it's not already solved.
   - type: textarea
     id: bug-description
     attributes:
@@ -45,8 +45,8 @@ body:
       label: Relevant log output
       description: >
         Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs 
-        at https://juju.is/docs/olm/juju-logs
+        Fetch the logs using `juju debug-log --replay`. Additional details on how to retrieve logs are available in the juju 
+        documentation at https://juju.is/docs/olm/juju-logs.
       render: shell
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
@@ -1,0 +1,17 @@
+name: Enhancement Proposal
+description: File an enhancement proposal
+labels: ["Type: Enhancement", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this enhancement proposal! Before submitting your issue, please make
+        sure there isn't already a prior issue concerning this. If there is, please join that discussion instead.
+  - type: textarea
+    id: enhancement-proposal
+    attributes:
+      label: Enhancement Proposal
+      description: >
+        Describe the enhancement you would like to see in as much detail as needed.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
@@ -5,8 +5,8 @@ body:
   - type: markdown
     attributes:
       value: >
-        Thanks for taking the time to fill out this enhancement proposal! Before submitting your issue, please make
-        sure there isn't already a prior issue concerning this. If there is, please join that discussion instead.
+        Thank you for taking the time to fill out this enhancement proposal! Before submitting your proposal, please
+        make sure there isn't a pre-existing similar proposal. If there is, please join that discussion instead.
   - type: textarea
     id: enhancement-proposal
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,10 @@ motivation and context. Is it a new feature? A bug fix? Does it address an exist
 ## How was the code tested?
 
 > Describe the conditions under which the code has been tested.
+> * Did you run the defined integration and units under `tests/`?
+> * Did you write new tests? Where are they located in the repository?
+> * Which undercloud did you use to perform the tests? LXD, vSphere, AWS, etc.
+> * What operating system did you test the charms on? Ubuntu 22.04, Ubuntu 20.04, CentOS 7, etc.
 
 ## Related issues and/or tasks
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Description
+
+> Provide a description of the purpose of this pull request, as well as its
+motivation and context. Is it a new feature? A bug fix? Does it address an existing issue?
+
+## How was the code tested?
+
+> Describe the conditions under which the code has been tested.
+
+## Related issues and/or tasks
+
+> Link any related issues or project board tasks to this pull request.
+
+## Checklist
+
+- [ ] I am the author of these changes, or I have the rights to submit them.
+- [ ] I have added the relevant changes to the README and/or documentation.
+- [ ] I have self reviewed my own code.
+- [ ] All requested changes and/or review comments have been resolved.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: slurmdbd charm tests
+on:
+  workflow_call:
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run linters
+        run: tox -e lint
+
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run tests
+        run: tox -e unit
+
+# TODO: Add integration tests once they have been decided upon.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,17 @@ on:
   pull_request:
 
 jobs:
+  inclusive-naming-check:
+    name: Inclusive naming check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run tests
+        uses: get-woke/woke-action@v0
+        with:
+          fail-on-error: true
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Canonical Ltd.
+   Copyright 2023 Canonical Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Canonical Ltd.
+   Copyright 2023 Omnivector, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Testing tools configuration
 [tool.coverage.run]
 branch = true
@@ -14,20 +17,26 @@ log_cli_level = "INFO"
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff]
+line-length = 99
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
-# Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import ops.testing
+from ops.model import ActiveStatus
+from ops.testing import Harness
+
+from charm import SlurmdbdCharm
+
+
+class TestCharm(unittest.TestCase):
+    def setUp(self):
+        ops.testing.SIMULATE_CAN_CONNECT = True
+        self.addCleanup(setattr, ops.testing, "SIMULATE_CAN_CONNECT", False)
+
+        self.harness = Harness(SlurmdbdCharm)
+        self.addCleanup(self.harness.cleanup)
+
+    def test_start(self):
+        # Simulate the charm starting
+        self.harness.begin_with_initial_hooks()
+
+        # Ensure we set an ActiveStatus with no message
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus())

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -105,7 +105,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Cannot start slurmdbd"))
 
     def test_on_db_unavailable(self) -> None:
-        """Test the that _on_db_available method works."""
+        """Test that _on_db_available method works."""
         self.harness.charm._db.on.database_unavailable.emit()
         self.assertEqual(self.harness.charm._stored.db_info, {})
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,25 +1,173 @@
 #!/usr/bin/env python3
 
+"""Test default charm events such as upgrade charm, install, etc."""
+
 import unittest
+from unittest.mock import PropertyMock, patch
 
 import ops.testing
-from ops.model import ActiveStatus
+from charm import SlurmdbdCharm
+from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
-from charm import SlurmdbdCharm
+ops.testing.SIMULATE_CAN_CONNECT = True
 
 
 class TestCharm(unittest.TestCase):
-    def setUp(self):
-        ops.testing.SIMULATE_CAN_CONNECT = True
-        self.addCleanup(setattr, ops.testing, "SIMULATE_CAN_CONNECT", False)
-
+    def setUp(self) -> None:
         self.harness = Harness(SlurmdbdCharm)
         self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
 
-    def test_start(self):
-        # Simulate the charm starting
-        self.harness.begin_with_initial_hooks()
+    @unittest.expectedFailure
+    def test_install_success(self) -> None:
+        """Test that slurmdbd can successfully be installed.
 
-        # Ensure we set an ActiveStatus with no message
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
+        Notes:
+            This method is expected to fail due to the 'version' file missing.
+        """
+        self.harness.charm.on.install.emit()
+        self.assertEqual(
+            self.harness.charm.unit.status, ActiveStatus("slurmdbd successfully installed")
+        )
+
+    @unittest.expectedFailure
+    @patch("slurm_ops_manager.SlurmManager.install")
+    def test_install_fail(self, install) -> None:
+        """Test that slurmdbd install fail handler works.
+
+        Notes:
+            This method is expected to fail due to the 'version' file missing.
+        """
+        install.side_effect = False
+        self.harness.charm.on.install.emit()
+        self.assertEqual(
+            self.harness.charm.unit.status, BlockedStatus("Error installing slurmdbd")
+        )
+
+    @patch("pathlib.Path.read_text", return_value="v1.0.0")
+    def test_upgrade_charm(self, _) -> None:
+        """Test that charm upgrade procedure works."""
+        self.harness.charm.on.upgrade_charm.emit()
+        self.assertEqual(self.harness.get_workload_version(), "v1.0.0")
+
+    @patch("ops.model.Unit.is_leader", return_value=True)
+    def test_is_leader(self, _) -> None:
+        """Test that _is_leader method works.
+
+        Notes:
+            The _is_leader method should be removed from charm.py
+            since _is_leader is already defined in ops.
+        """
+        self.assertEqual(self.harness.charm._is_leader(), self.harness.charm.unit.is_leader())
+
+    @patch("ops.model.Unit.is_leader", return_value=False)
+    def test_is_not_leader(self, _) -> None:
+        """Test opposite case of _is_leader method."""
+        self.assertEqual(self.harness.charm._is_leader(), self.harness.charm.unit.is_leader())
+
+    @patch("slurm_ops_manager.SlurmManager.needs_reboot", return_value=True)
+    def test_check_status_needs_reboot(self, _) -> None:
+        """Test that _check_status method works if unit needs reboot."""
+        res = self.harness.charm._check_status()
+        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Machine needs reboot"))
+        self.assertFalse(
+            res, msg="_check_status returned value True instead of expected value False."
+        )
+
+    @patch(
+        "slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False)
+    )
+    def test_check_status_slurm_not_installed(self, _) -> None:
+        """Test that _check_status method works if slurm is not installed."""
+
+        self.harness.charm._stored.slurm_installed = True
+        res = self.harness.charm._check_status()
+        self.assertEqual(self.harness.charm.unit.status, BlockedStatus('Need relations: MySQL,slurcmtld'))
+        self.assertFalse(
+            res, msg="_check_status returned value True instead of expected value False."
+        )
+
+    @patch("slurm_ops_manager.SlurmManager.install")
+    @patch("slurm_ops_manager.SlurmManager.restart_slurm_component")
+    @patch("slurm_ops_manager.SlurmManager.slurm_is_active", return_value=True)
+    @patch("charm.SlurmdbdCharm._check_status")
+    def test_check_slurmdbd(self, *_) -> None:
+        """Test that _check_slurmdbd method works."""
+        self.harness.charm._check_slurmdbd(max_attemps=1)
+        self.assertNotEqual(self.harness.charm.unit.status, BlockedStatus("Cannot start slurmdbd"))
+
+    @patch("slurm_ops_manager.SlurmManager.slurm_is_active", return_value=False)
+    @patch("slurm_ops_manager.SlurmManager.restart_slurm_component")
+    def test_check_slurmdbd_slurm_not_active(self, *_) -> None:
+        """Test that proper block status is thrown if slurm is not active."""
+        self.harness.charm._check_slurmdbd(max_attemps=1)
+        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Cannot start slurmdbd"))
+
+    def test_on_db_unavailable(self) -> None:
+        """Test the that _on_db_available method works."""
+        self.harness.charm._db.on.database_unavailable.emit()
+        self.assertEqual(self.harness.charm._stored.db_info, {})
+
+    @unittest.expectedFailure
+    def test_on_jwt_available(self) -> None:
+        """Test that _on_jwt_available method works.
+
+        Notes:
+            This test is expected to fail due to jwt_rsa being in StoredState
+            in a separate class.
+        """
+        self.harness.charm._stored.slurm_installed = True
+        self.harness.charm.on.jwt_available.emit()
+        self.assertTrue(self.harness.charm._stored.jwt_available)
+
+    @patch("interface_slurmdbd.Slurmdbd.get_munge_key")
+    @patch("slurm_ops_manager.SlurmManager.configure_munge_key")
+    @patch("slurm_ops_manager.SlurmManager.restart_munged", return_value=True)
+    def test_on_munge_available(self, *_) -> None:
+        """Test that _on_munge_available method works."""
+        self.harness.charm._stored.slurm_installed = True
+        self.harness.charm.on.munge_available.emit()
+        self.assertTrue(self.harness.charm._stored.munge_available)
+
+    @patch("interface_slurmdbd.Slurmdbd.get_munge_key")
+    @patch("slurm_ops_manager.SlurmManager.configure_munge_key")
+    @patch("slurm_ops_manager.SlurmManager.restart_munged", return_value=False)
+    def test_on_munge_available_fail_restart(self, *_) -> None:
+        """Test that _on_munge_available properly handles when munge fails to restart."""
+        self.harness.charm._stored.slurm_installed = True
+        self.harness.charm.on.munge_available.emit()
+        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Error restarting munge"))
+
+    def test_on_slurmctld_unavailable(self) -> None:
+        """Test that _on_slurmctld_unavailable method works."""
+        self.harness.charm._slurmdbd.on.slurmctld_unavailable.emit()
+        self.assertFalse(self.harness.charm._stored.jwt_available)
+        self.assertFalse(self.harness.charm._stored.munge_available)
+
+    @patch("slurm_ops_manager.SlurmManager.port", return_value=12345)
+    def test_get_port(self, port) -> None:
+        """Test that get_port method works."""
+        self.assertEqual(self.harness.charm.get_port(), port)
+
+    @patch("slurm_ops_manager.SlurmManager.hostname", return_value="localhost")
+    def test_get_hostname(self, hostname) -> None:
+        """Test that get_hostname method works."""
+        self.assertEqual(self.harness.charm.get_hostname(), hostname)
+
+    def test_set_db_info(self) -> None:
+        """Test that set_db_info method works."""
+        db_test_info = {
+            "db_username": "test",
+            "db_password": "default",
+            "db_hostname": "localhost",
+            "db_port": "3306",
+            "db_name": "slurmdbd_accounting",
+        }
+        self.harness.charm.set_db_info(db_test_info)
+        self.assertEqual(self.harness.charm._stored.db_info, db_test_info)
+
+    def test_cluster_name(self) -> None:
+        """Test that the cluster name property works."""
+        self.harness.charm.cluster_name = "test-cluster"
+        self.assertEqual(self.harness.charm.cluster_name, "test-cluster")

--- a/tox.ini
+++ b/tox.ini
@@ -9,14 +9,13 @@ envlist = lint, unit
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-;lib_path = {toxinidir}/lib/charms/operator_name_with_underscores
 all_path = {[vars]src_path} {[vars]tst_path} 
 
 [testenv]
 setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-  PYTHONBREAKPOINT=pdb.set_trace
-  PY_COLORS=1
+    PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
+    PYTHONBREAKPOINT=pdb.set_trace
+    PY_COLORS=1
 passenv =
   PYTHONPATH
   CHARM_BUILD_DIR
@@ -26,30 +25,23 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8-docstrings
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
+    ruff
     codespell
 commands =
-    # uncomment the following line if this charm owns a lib
-    # codespell {[vars]lib_path}
     codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:unit]
@@ -59,16 +51,7 @@ deps =
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =
-    coverage run --source={[vars]src_path} \
-        -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
+    coverage run \
+        --source={[vars]src_path} \
+        -m pytest -v --tb native -s {posargs} {[vars]tst_path}unit
     coverage report
-
-[testenv:integration]
-description = Run integration tests
-deps =
-    pytest
-    juju
-    pytest-operator
-    -r{toxinidir}/requirements.txt
-commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
Greetings folks! Here is the first pull request that I have for the slurmdbd charm. Here is a summary of the changes that I have made below:

* I added templates for bug reports, enhancement requests, and pull requests. The pull request template is largely built off of the original pull request template in `ov-slurm-charms`. The bug report and enhancement requests are intended to help with the triaging process.
* I added a basic CI pipeline using GitHub actions. Currently, there are three jobs run:
   * _Inclusive language check_ <- this action audits the source code of the charm to ensure there is no offensive/non-inclusive language present.
   * _Lint_ <- Checks spelling and lints the source code using [codespell](https://github.com/codespell-project/codespell) and [ruff](https://github.com/charliermarsh/ruff). This job currently fails due to the charm source code not passing spellcheck or lint rules. I plan on fixing these issues in a later pull request.
   * _Unit tests_ <- Runs unit tests defined in `tests/unit`.
* Lastly, I added an initial suite of unit tests for the slurmdbd charm using `Harness` provided by ops. Test coverage is currently around 50%, but this will be improved as we progressively add more unit tests.

Please feel more than welcome to look over my proposed changes and raise any questions, comments, or concerns should you have them!