### PR TITLE
Drop needs_reboot conditional in `_check_status(...)`

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -5,7 +5,6 @@
 """Slurmdbd Operator Charm."""
 
 import logging
-import subprocess
 from pathlib import Path
 from time import sleep
 from typing import Any, Dict
@@ -20,7 +19,7 @@ from interface_slurmdbd_peer import SlurmdbdPeer
 from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource, StoredState
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from slurm_ops_manager import SlurmManager
 from utils.manager import SlurmdbdManager
 
@@ -245,15 +244,6 @@ class SlurmdbdCharm(CharmBase):
 
     def _check_status(self) -> bool:  # noqa C901
         """Check that we have the things we need."""
-        if self._slurm_manager.needs_reboot:
-            try:
-                self.unit.status = MaintenanceStatus("Rebooting...")
-                logger.debug("Scheduling machine reboot")
-                subprocess.run(["juju-reboot"], check=True)
-            except subprocess.CalledProcessError:
-                logger.error("Failed to schedule machine reboot")
-            return False
-
         slurm_installed = self._stored.slurm_installed
         if not slurm_installed:
             self.unit.status = BlockedStatus("Error installing slurm")

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,6 +5,7 @@
 """Slurmdbd Operator Charm."""
 
 import logging
+import subprocess
 from pathlib import Path
 from time import sleep
 from typing import Any, Dict
@@ -19,7 +20,7 @@ from interface_slurmdbd_peer import SlurmdbdPeer
 from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource, StoredState
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from slurm_ops_manager import SlurmManager
 from utils.manager import SlurmdbdManager
 
@@ -242,10 +243,15 @@ class SlurmdbdCharm(CharmBase):
         else:
             self.unit.status = BlockedStatus("Cannot start slurmdbd")
 
-    def _check_status(self) -> bool:
+    def _check_status(self) -> bool:  # noqa C901
         """Check that we have the things we need."""
         if self._slurm_manager.needs_reboot:
-            self.unit.status = BlockedStatus("Machine needs reboot")
+            try:
+                self.unit.status = MaintenanceStatus("Rebooting...")
+                logger.debug("Scheduling machine reboot")
+                subprocess.run(["juju-reboot"], check=True)
+            except subprocess.CalledProcessError:
+                logger.error("Failed to schedule machine reboot")
             return False
 
         slurm_installed = self._stored.slurm_installed

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -20,7 +20,7 @@ from unittest.mock import PropertyMock, patch
 
 import ops.testing
 from charm import SlurmdbdCharm
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
 ops.testing.SIMULATE_CAN_CONNECT = True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -79,21 +79,7 @@ class TestCharm(unittest.TestCase):
         """Test opposite case of _is_leader method."""
         self.assertEqual(self.harness.charm._is_leader(), self.harness.charm.unit.is_leader())
 
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", return_value=True)
-    @patch("subprocess.run")
-    def test_check_status_needs_reboot(self, *_) -> None:
-        """Test that _check_status method works if unit needs reboot."""
-        res = self.harness.charm._check_status()
-        self.assertEqual(self.harness.charm.unit.status, MaintenanceStatus("Rebooting..."))
-        self.assertFalse(
-            res, msg="_check_status returned value True instead of expected value False."
-        )
-
-    @patch(
-        "slurm_ops_manager.SlurmManager.needs_reboot",
-        new_callable=PropertyMock(return_value=False),
-    )
-    def test_check_status_slurm_not_installed(self, _) -> None:
+    def test_check_status_slurm_not_installed(self) -> None:
         """Test that _check_status method works if slurm is not installed."""
         self.harness.charm._stored.slurm_installed = True
         res = self.harness.charm._check_status()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -84,7 +84,7 @@ class TestCharm(unittest.TestCase):
     def test_check_status_needs_reboot(self, *_) -> None:
         """Test that _check_status method works if unit needs reboot."""
         res = self.harness.charm._check_status()
-        self.assertEqual(self.harness.charm.unit.status, MaintenanceStatus("Rebooting"))
+        self.assertEqual(self.harness.charm.unit.status, MaintenanceStatus("Rebooting..."))
         self.assertFalse(
             res, msg="_check_status returned value True instead of expected value False."
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -20,7 +20,7 @@ from unittest.mock import PropertyMock, patch
 
 import ops.testing
 from charm import SlurmdbdCharm
-from ops.model import ActiveStatus, BlockedStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
 
 ops.testing.SIMULATE_CAN_CONNECT = True
@@ -80,10 +80,11 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.charm._is_leader(), self.harness.charm.unit.is_leader())
 
     @patch("slurm_ops_manager.SlurmManager.needs_reboot", return_value=True)
-    def test_check_status_needs_reboot(self, _) -> None:
+    @patch("subprocess.run")
+    def test_check_status_needs_reboot(self, *_) -> None:
         """Test that _check_status method works if unit needs reboot."""
         res = self.harness.charm._check_status()
-        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Machine needs reboot"))
+        self.assertEqual(self.harness.charm.unit.status, MaintenanceStatus("Rebooting"))
         self.assertFalse(
             res, msg="_check_status returned value True instead of expected value False."
         )


### PR DESCRIPTION
## Description

This pull request adds `juju-reboot` to the `_check_status(...)` function so that the machine will automatically restart if it needs security updates applied. Using `juju-reboot` helps with automatic deployments as a human-operator is not required to manually intervene when the slurmdbd charm is first deployed.

## How was the code tested?

I tested this charm on a private OpenStack instance with ubuntu@22.04 base images that needed security updates to be deployed.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
