### PR TITLE
Add support for Ubuntu 22.04: part 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,13 @@ jobs:
         run: tox -e unit
 
   integration-test:
-    name: Integration tests (LXD)
+    strategy:
+      fail-fast: true
+      matrix:
+        bases:
+          - ubuntu@20.04
+          - ubuntu@22.04
+    name: Integration tests (LXD) | ${{ matrix.bases }}
     runs-on: ubuntu-latest
     needs:
       - inclusive-naming-check
@@ -67,4 +73,4 @@ jobs:
           provider: lxd
           juju-channel: 3.1/stable
       - name: Run tests
-        run: tox -e integration
+        run: tox run -e integration -- --charm-base=${{ matrix.bases }}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,8 +18,21 @@
 import pathlib
 
 import pytest
+from _pytest.config.argparsing import Parser
 from helpers import ETCD, VERSION
 from pytest_operator.plugin import OpsTest
+
+
+def pytest_addoption(parser: Parser) -> None:
+    parser.addoption(
+        "--charm-base", action="store", default="ubuntu@22.04", help="Charm base to test."
+    )
+
+
+@pytest.fixture(scope="module")
+def charm_base(request) -> str:
+    """Get slurmdbd charm base to use."""
+    return request.config.getoption("--charm-base")
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,7 +34,7 @@ VERSION_NUM = subprocess.run(
 def get_slurmctld_res() -> Dict[str, pathlib.Path]:
     """Get slurmctld resources needed for charm deployment."""
     if not (etcd := pathlib.Path(ETCD)).exists():
-        logger.info(f"Getting resource {ETCD} from {ETCD_URL}...")
+        logger.info(f"Getting resource {ETCD} from {ETCD_URL}")
         request.urlretrieve(ETCD_URL, etcd)
 
     return {"etcd": etcd}
@@ -44,5 +43,5 @@ def get_slurmctld_res() -> Dict[str, pathlib.Path]:
 def get_slurmdbd_res() -> None:
     """Get slurmdbd charm resources needed for deployment."""
     if not (version := pathlib.Path(VERSION)).exists():
-        logger.info(f"Setting resource {VERSION} to value {VERSION_NUM}...")
+        logger.info(f"Setting resource {VERSION} to value {VERSION_NUM}")
         version.write_text(VERSION_NUM)

--- a/tox.ini
+++ b/tox.ini
@@ -56,17 +56,16 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    -r{toxinidir}/requirements.txt
     juju==3.1.0.1
     pytest==7.2.0
-    pytest_operator==0.23.0
-    tenacity==8.1.0
+    pytest-operator==0.26.0
+    pytest-order==1.1.0
+    tenacity==8.2.2
+    -r{toxinidir}/requirements.txt
 commands =
     pytest -v \
-           -s \
-           --tb native \
-           --ignore={[vars]tst_path}unit \
-           --log-cli-level=INFO \
-           --model controller \
-           --keep-models \
-           {posargs}
+        -s \
+        --tb native \
+        --log-cli-level=INFO \
+        {[vars]tst_path}integration \
+        {posargs}


### PR DESCRIPTION
## Description

This pull request updates the slurmdbd integration tests to test the charm on both Ubuntu 20.04 and 22.04 bases. With the 22.04 SLURM charms published, we no longer have the chicken and egg problem :sweat_smile: 

## How was the code tested?

I ran the updated integration locally on my Ubuntu 22.04 workstation.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
