### PR TITLE
Configure database per the DatabaseCreatedEvent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ops==2.*
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.12
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.14

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,7 @@
 import logging
 from pathlib import Path
 from time import sleep
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseCreatedEvent,
@@ -19,11 +19,15 @@ from interface_slurmdbd_peer import SlurmdbdPeer
 from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource, StoredState
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, ErrorStatus, WaitingStatus
 from slurm_ops_manager import SlurmManager
 from utils.manager import SlurmdbdManager
 
 logger = logging.getLogger(__name__)
+
+
+SLURM_ACCT_DB = "slurm_acct_db"
+SLURMDBD_DEFAULTS = Path("/etc/default/slurmdbd")
 
 
 class JwtAvailable(EventBase):
@@ -65,7 +69,7 @@ class SlurmdbdCharm(CharmBase):
         )
 
         self._slurmdbd_manager = SlurmdbdManager()
-        self._db = DatabaseRequires(self, relation_name="database", database_name="slurm_acct_db")
+        self._db = DatabaseRequires(self, relation_name="database", database_name=SLURM_ACCT_DB)
         self._slurm_manager = SlurmManager(self, "slurmdbd")
         self._slurmdbd = Slurmdbd(self, "slurmdbd")
         self._slurmdbd_peer = SlurmdbdPeer(self, "slurmdbd-peer")
@@ -155,23 +159,166 @@ class SlurmdbdCharm(CharmBase):
             self.unit.status = BlockedStatus("Error restarting munge")
             event.defer()
 
+    @classmethod
+    def _update_defaults(cls, **kwargs: Optional[str]):
+        """Update the environment settings in the /etc/defaults/slurmdbd file.
+
+        Updates the slurmdbd defaults environment file to add the specified
+        defaults. For example, to add the MY_VAR environment variable invoke with
+
+            self._update_defaults(my_var="foobar")
+
+        The key will be converted to all uppercase prior to being written to
+        the specified file. To remove a setting, specify the value as None, e.g.:
+
+            self._update_defaults(my_var=None)
+
+        Note: variable names will be converted to upper case when being written
+        to the file and for comparison of keys.
+
+        Args:
+            **kwargs:
+                The environment variables that should be set or unset. The key
+                will be upper-cased for the environment variable.
+        """
+        with open("/etc/default/slurmdbd", "w+") as f:
+            updated_contents = []
+
+            keys_processed = set()
+
+            for line in f.readlines():
+                # Lines beginning with a hash are a comment. Don't process these
+                # but do add the line to the output buffer to preserve it.
+                if line.startswith("#"):
+                    updated_contents.append(line)
+                    continue
+
+                # Attempt to get the environment variable and split it on the =.
+                # If the line doesn't have an equals, then don't process the line
+                # but do add the line to the output buffer to preserve it.
+                line_parts = line.split("=", 1)
+                if len(line_parts) < 2:
+                    updated_contents.append(line)
+                    continue
+
+                var_name = line_parts[0].lower()
+                if var_name not in kwargs:
+                    updated_contents.append(line)
+                    continue
+
+                keys_processed.add(var_name)
+                # If explicitly None, then remove from the output buffer as
+                # the demand is to unset the variable.
+                if kwargs[var_name] is None:
+                    continue
+
+                updated_contents.append(f"{var_name.upper()}={kwargs[var_name]}\n")
+
+            for key, value in kwargs.items():
+                # Skip any keys already processed.
+                if key in keys_processed:
+                    continue
+                updated_contents.append(f"{key.upper()}={value}\n")
+
+            f.seek(0)
+            f.truncate()
+            f.writelines(updated_contents)
+
     def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
-        """Set database info in StoredState and invoke _write_config_and_restart_slurmdbd.
+        """Process the DatabaseCreatedEvent and updates the database parameters.
+
+        Updates the database parameters for the slurmdbd configuration based up on the
+        DatabaseCreatedEvent. The type of update depends on the endpoints provided in
+        the DatabaseCreatedEvent.
+
+        If the endpoints provided are file paths to unix sockets
+        then the /etc/default/slurmdbd file will be updated to tell the MySQL client to
+        use the socket.
+
+        If the endpoints provided are Address:Port tuples, then the address and port are
+        updated as the database parameters in the slurmdbd.conf configuration file.
 
         Args:
             event (DatabaseCreatedEvent):
                 Information passed by MySQL after the slurm_acct_db database has been created.
+
+        Raises:
+            ValueError:
+                When the database endpoints are invalid (e.g. empty).
         """
         logger.debug("Configuring new backend database for slurmdbd.")
-        self.set_db_info(
-            {
-                "db_username": event.username,
-                "db_password": event.password,
-                "db_hostname": "127.0.0.1",
-                "db_port": "3306",
-                "db_name": "slurm_acct_db",
-            }
-        )
+
+        socket_endpoints = []
+        tcp_endpoints = []
+        if not event.endpoints:
+            # This is 100% an error condition that the charm doesn't know how to handle
+            # and is an unexpected condition. Raise an error here to fail the hook in
+            # a bad way. The event isn't deferred as this is a situation that requires
+            # a human to look at and resolve the proper next steps. Reprocessing the
+            # deferred event will only result in continual errors.
+            logger.error(f"No endpoints provided: {event.endpoints}")
+            self.unit.status = ErrorStatus("No database endpoints")
+            raise ValueError(f"Unexpected endpoint types: {event.endpoints}")
+
+        for endpoint in [ep.strip() for ep in event.endpoints.split(",")]:
+            if not endpoint:
+                continue
+
+            if endpoint.startswith("file://"):
+                socket_endpoints.append(endpoint)
+            else:
+                tcp_endpoints.append(endpoint)
+
+        db_info = {
+            "db_username": event.username,
+            "db_password": event.password,
+            "db_name": SLURM_ACCT_DB,
+        }
+
+        if socket_endpoints:
+            # Socket endpoints will be preferred. This is the case when the mysql
+            # configuration is using the mysql-router on the local node.
+            logger.debug("Updating environment for mysql socket access")
+            if len(socket_endpoints) > 1:
+                logger.warning(
+                    f"{len(socket_endpoints)} socket endpoints are specified, "
+                    f"but only first one will be used."
+                )
+            # Make sure to strip the file:// off the front of the first endpoint
+            # otherwise slurmdbd will not be able to connect to the database
+            socket = socket_endpoints[0][7:]
+            self._update_defaults(mysql_unix_port=f'"{socket}"')
+        elif tcp_endpoints:
+            # This must be using TCP endpoint and the connection information will
+            # be host_address:port. Only one remote mysql service will be configured
+            # in this case.
+            logger.debug("Using tcp endpoints specified in the relation.")
+            if len(tcp_endpoints) > 1:
+                logger.warning(
+                    f"{len(tcp_endpoints)} tcp endpoints are specified, "
+                    f"but only the first one will be used."
+                )
+            addr, port = tcp_endpoints[0].rsplit(":", 1)
+            # Check IPv6 and strip any brackets
+            if addr.startswith("[") and addr.endswith("]"):
+                addr = addr[1:-1]
+            db_info.update(
+                {
+                    "db_hostname": addr,
+                    "db_port": port,
+                }
+            )
+            # Make sure that the MYSQL_UNIX_PORT is removed from the env file.
+            self._update_defaults(mysql_unix_port=None)
+        else:
+            # This is 100% an error condition that the charm doesn't know how to handle
+            # and is an unexpected condition. This happens when there are commas but no
+            # usable data in the endpoints.
+            logger.error(f"No endpoints provided: {event.endpoints}")
+            self.unit.status = ErrorStatus("No database endpoints")
+            raise ValueError(f"No endpoints provided: {event.endpoints}")
+
+        self.set_db_info(db_info)
         self._write_config_and_restart_slurmdbd(event)
 
     def _on_slurmctld_available(self, event):

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,6 +8,7 @@ import logging
 from pathlib import Path
 from time import sleep
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseCreatedEvent,
@@ -286,8 +287,8 @@ class SlurmdbdCharm(CharmBase):
                 )
             # Make sure to strip the file:// off the front of the first endpoint
             # otherwise slurmdbd will not be able to connect to the database
-            socket = socket_endpoints[0][7:]
-            self._update_defaults(mysql_unix_port=f'"{socket}"')
+            socket = urlparse(socket_endpoints[0]).path
+            self._slurmdbd_manager.set_environment_var(mysql_unix_port=f'"{socket}"')
         elif tcp_endpoints:
             # This must be using TCP endpoint and the connection information will
             # be host_address:port. Only one remote mysql service will be configured

--- a/src/utils/manager.py
+++ b/src/utils/manager.py
@@ -14,6 +14,9 @@
 
 """Manager for unit slurmdbd service."""
 
+from pathlib import Path
+from typing import Optional
+
 from charms.operator_libs_linux.v1.systemd import (
     service_restart,
     service_running,
@@ -22,6 +25,8 @@ from charms.operator_libs_linux.v1.systemd import (
 )
 
 from .confeditor import SlurmdbdConfEditor
+
+SLURMDBD_DEFAULTS = Path("/etc/default/slurmdbd")
 
 
 class SlurmdbdManager:
@@ -55,3 +60,68 @@ class SlurmdbdManager:
     def restart() -> None:
         """Restart slurmdbd service."""
         service_restart("slurmdbd")
+
+    @classmethod
+    def set_environment_var(cls, **kwargs: Optional[str]):
+        """Update the environment settings in the /etc/defaults/slurmdbd file.
+
+        Updates the slurmdbd defaults environment file to add the specified
+        defaults. For example, to add the MY_VAR environment variable invoke with
+
+            self._update_defaults(my_var="foobar")
+
+        The key will be converted to all uppercase prior to being written to
+        the specified file. To remove a setting, specify the value as None, e.g.:
+
+            self._update_defaults(my_var=None)
+
+        Note: variable names will be converted to upper case when being written
+        to the file and for comparison of keys.
+
+        Args:
+            **kwargs:
+                The environment variables that should be set or unset. The key
+                will be upper-cased for the environment variable.
+        """
+        with open(SLURMDBD_DEFAULTS, "w+") as f:
+            updated_contents = []
+
+            keys_processed = set()
+
+            for line in f.readlines():
+                # Lines beginning with a hash are a comment. Don't process these
+                # but do add the line to the output buffer to preserve it.
+                if line.startswith("#"):
+                    updated_contents.append(line)
+                    continue
+
+                # Attempt to get the environment variable and split it on the =.
+                # If the line doesn't have an equals, then don't process the line
+                # but do add the line to the output buffer to preserve it.
+                line_parts = line.split("=", 1)
+                if len(line_parts) < 2:
+                    updated_contents.append(line)
+                    continue
+
+                var_name = line_parts[0].lower()
+                if var_name not in kwargs:
+                    updated_contents.append(line)
+                    continue
+
+                keys_processed.add(var_name)
+                # If explicitly None, then remove from the output buffer as
+                # the demand is to unset the variable.
+                if kwargs[var_name] is None:
+                    continue
+
+                updated_contents.append(f"{var_name.upper()}={kwargs[var_name]}\n")
+
+            for key, value in kwargs.items():
+                # Skip any keys already processed.
+                if key in keys_processed:
+                    continue
+                updated_contents.append(f"{key.upper()}={value}\n")
+
+            f.seek(0)
+            f.truncate()
+            f.writelines(updated_contents)

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test the slurmdbd manager class."""
+
+import unittest
+from unittest.mock import mock_open, patch
+
+from utils.confeditor import SlurmdbdConfEditor
+from utils.manager import SlurmdbdManager
+
+
+class TestCharm(unittest.TestCase):
+    def setUp(self) -> None:
+        self.slurmdbd_manager = SlurmdbdManager()
+
+    @patch("pathlib.Path.exists", return_value=False)
+    @patch("pathlib.Path.touch")
+    def test_conf(self, *_):
+        """Tests conf that gives a confeditor."""
+        conf_editor = self.slurmdbd_manager.conf
+        self.assertIsNotNone(conf_editor)
+        self.assertTrue(isinstance(conf_editor, SlurmdbdConfEditor))
+
+    @patch("utils.manager.service_running")
+    def test_active(self, _service_running):
+        """Tests that active returns the service state."""
+        _service_running.return_value = False
+        self.assertFalse(self.slurmdbd_manager.active)
+        _service_running.assert_called_once_with("slurmdbd")
+
+        _service_running.reset_mock()
+        _service_running.return_value = True
+        self.assertTrue(self.slurmdbd_manager.active)
+        _service_running.assert_called_once_with("slurmdbd")
+
+    @patch("utils.manager.service_start")
+    def test_start(self, _service_start):
+        """Tests that start attempts to start the service."""
+        self.slurmdbd_manager.start()
+        _service_start.assert_called_once_with("slurmdbd")
+
+    @patch("utils.manager.service_stop")
+    def test_stop(self, _service_stop):
+        """Tests that start attempts to stop the service."""
+        self.slurmdbd_manager.stop()
+        _service_stop.assert_called_once_with("slurmdbd")
+
+    @patch("utils.manager.service_restart")
+    def test_restart(self, _service_restart):
+        """Tests that restart attempts to restart the service."""
+        self.slurmdbd_manager.restart()
+        _service_restart.assert_called_once_with("slurmdbd")
+
+    def test_set_environment_var_add_variable_to_end(self):
+        """Tests that the set_environment_var adds a new environment variable."""
+        content = (
+            "# Additional options that are passed to the slurmdbd daemon\n"
+            '#SLURMDBD_OPTIONS=""\n'
+        )
+        m = mock_open(read_data=content)
+        with patch("builtins.open", m, create=True):
+            self.slurmdbd_manager.set_environment_var(mysql_unix_port='"/path/to/file"')
+
+        handle = m()
+        handle.writelines.assert_called_once_with(
+            [
+                "# Additional options that are passed to the slurmdbd daemon\n",
+                '#SLURMDBD_OPTIONS=""\n',
+                'MYSQL_UNIX_PORT="/path/to/file"\n',
+            ]
+        )
+
+    def test_set_environment_var_variable_already_defined(self):
+        """Tests that the set_environment_var updates an environment variable."""
+        content = (
+            "# Additional options that are passed to the slurmdbd daemon\n"
+            '#SLURMDBD_OPTIONS=""\n'
+            "TEST_ENV_VAR=foo\n"
+        )
+        m = mock_open(read_data=content)
+        with patch("builtins.open", m, create=True):
+            self.slurmdbd_manager.set_environment_var(test_env_var="bar")
+
+        handle = m()
+        handle.writelines.assert_called_once_with(
+            [
+                "# Additional options that are passed to the slurmdbd daemon\n",
+                '#SLURMDBD_OPTIONS=""\n',
+                "TEST_ENV_VAR=bar\n",
+            ]
+        )
+
+    def test_set_environment_var_no_updates_existing(self):
+        """Tests that the _update_defaults only changes desired values."""
+        content = (
+            "# Additional options that are passed to the slurmdbd daemon\n"
+            '#SLURMDBD_OPTIONS=""\n'
+            "TEST_ENV_VAR=foo\n"
+            "TEST_STABLE=don't change me\n"
+        )
+        m = mock_open(read_data=content)
+        with patch("builtins.open", m, create=True):
+            self.slurmdbd_manager.set_environment_var(test_env_var="bar")
+
+        handle = m()
+        handle.writelines.assert_called_once_with(
+            [
+                "# Additional options that are passed to the slurmdbd daemon\n",
+                '#SLURMDBD_OPTIONS=""\n',
+                "TEST_ENV_VAR=bar\n",
+                "TEST_STABLE=don't change me\n",
+            ]
+        )
+
+    def test_set_environment_var_remove_existing(self):
+        """Tests that the set_environment_var removes a value."""
+        content = (
+            "# Additional options that are passed to the slurmdbd daemon\n"
+            '#SLURMDBD_OPTIONS=""\n'
+            "TEST_ENV_VAR=foo\n"
+            "TEST_STABLE=don't change me\n"
+        )
+        m = mock_open(read_data=content)
+        with patch("builtins.open", m, create=True):
+            self.slurmdbd_manager.set_environment_var(test_env_var=None)
+
+        handle = m()
+        handle.writelines.assert_called_once_with(
+            [
+                "# Additional options that are passed to the slurmdbd daemon\n",
+                '#SLURMDBD_OPTIONS=""\n',
+                "TEST_STABLE=don't change me\n",
+            ]
+        )
+
+    def test_set_environment_var_mixed_scenario(self):
+        """Tests that the set_environment_var adds, updates and removes a value."""
+        content = (
+            "# Additional options that are passed to the slurmdbd daemon\n"
+            '#SLURMDBD_OPTIONS=""\n'
+            "DONT_TOUCH_ME\n"
+            "TEST_UPDATE=foo\n"
+            "TEST_REMOVE=remove me\n"
+        )
+        m = mock_open(read_data=content)
+        with patch("builtins.open", m, create=True):
+            self.slurmdbd_manager.set_environment_var(
+                test_update="bar", test_remove=None, test_new="added"
+            )
+
+        handle = m()
+        handle.writelines.assert_called_once_with(
+            [
+                "# Additional options that are passed to the slurmdbd daemon\n",
+                '#SLURMDBD_OPTIONS=""\n',
+                "DONT_TOUCH_ME\n",
+                "TEST_UPDATE=bar\n",
+                "TEST_NEW=added\n",
+            ]
+        )


### PR DESCRIPTION
## Description

The DatabaseCreatedEvent handler took a rather simple approach to defining database connections and always used a local TCP connection to the MySQL Router on a standard port. This worked at the time, but depended on behavior which has since changed. Instead, this patch changes the _on_database_created event handler to process the endpoints and configure the slurmdbd service based upon the the endpoints.

The database relation is a generic relation and allows for the slurmdbd charm to be connected to either a mysql-router charm or to a mysql service, depending on whether the database service is configured for high availability or not. The changes in this patch handle both scenarios, ensuring that the charm properly attempts to configure itself as directed by the relation data.

In a highly available configuration, the mysql-router subordinate charm will be configured for connections and the slurmdbd service will use the unix socket for communication. This involves specifying environment variables to the slurmdbd process to indicate which socket to use.

If the slurmdbd charm is related directly to mysql then the slurmdbd service will connect over a TCP socket. In this case, the slurmdbd.conf file can be updated to point to the host address and port that the mysql service is listening on.

## How was the code tested?

Code was tested in multiple ways:
 - [X] Unit Tests (new and existing)
 - [X] Integration Tests (existing)
 - [X] Manual Tests
   - Log into machines, verify all the necessary bits are properly set
   - Verify that services are running
   - Verify that database schemas are created

Operating Systems Tested on:
 - [X] Ubuntu 22.04
 - [ ] Ubuntu 20.04
 - [ ] Centos 7

## Related issues and/or tasks

This PR depends on https://github.com/omnivector-solutions/slurm-ops-manager/pull/97. It will not run integration tests successfully until the slurmdbd configuration template has the option to skip defining the StorageHost and StoragePort options.

*Note: The referenced change in the slurm-ops-manager may need to be backported as the slurmdbd-operator currently depends on the 0.8.12 branch of slurm-ops-manager.*

## Checklist

- [X] I am the author of these changes, or I have the rights to submit them.
- [X] I have added the relevant changes to the README and/or documentation.
- [X] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
