### PR TITLE
Auto-generate version file when slurmdbd operator is packed 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,8 +31,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Create version file
-        run: git describe --tags --always --dirty > version
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.2.0
         id: channel

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,3 +1,6 @@
+# Copyright 2020 Omnivector Solutions, LLC.
+# See LICENSE file for licensing details.
+
 type: charm
 bases:
   - build-on:
@@ -13,7 +16,22 @@ bases:
       - name: centos
         channel: "7"
         architectures: [amd64]
+
 parts:
   charm:
     build-packages: [git]
     charm-python-packages: [setuptools]
+
+  # Create a version file and pack it into the charm. This is dynamically generated
+  # as part of the build process for a charm to ensure that the git revision of the
+  # charm is always recorded in this version file.
+  version-file:
+    plugin: nil
+    build-packages:
+      - git
+    override-build: |
+      VERSION=$(git -C $CRAFT_PART_SRC/../../charm/src describe --dirty --always)
+      echo "Setting version to $VERSION"
+      echo $VERSION > $CRAFT_PART_INSTALL/version
+    stage:
+      - version

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,7 +19,7 @@ import pathlib
 
 import pytest
 from _pytest.config.argparsing import Parser
-from helpers import ETCD, VERSION
+from helpers import ETCD
 from pytest_operator.plugin import OpsTest
 
 
@@ -45,4 +45,3 @@ async def slurmdbd_charm(ops_test: OpsTest):
 def pytest_sessionfinish(session, exitstatus) -> None:
     """Clean up repository after test session has completed."""
     pathlib.Path(ETCD).unlink(missing_ok=True)
-    pathlib.Path(VERSION).unlink(missing_ok=True)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -25,11 +25,6 @@ logger = logging.getLogger(__name__)
 
 ETCD = "etcd-v3.5.0-linux-amd64.tar.gz"
 ETCD_URL = f"https://github.com/etcd-io/etcd/releases/download/v3.5.0/{ETCD}"
-VERSION = "version"
-VERSION_NUM = subprocess.run(
-    shlex.split("git describe --always"), stdout=subprocess.PIPE, text=True
-).stdout.strip("\n")
-
 
 def get_slurmctld_res() -> Dict[str, pathlib.Path]:
     """Get slurmctld resources needed for charm deployment."""
@@ -38,10 +33,3 @@ def get_slurmctld_res() -> Dict[str, pathlib.Path]:
         request.urlretrieve(ETCD_URL, etcd)
 
     return {"etcd": etcd}
-
-
-def get_slurmdbd_res() -> None:
-    """Get slurmdbd charm resources needed for deployment."""
-    if not (version := pathlib.Path(VERSION)).exists():
-        logger.info(f"Setting resource {VERSION} to value {VERSION_NUM}")
-        version.write_text(VERSION_NUM)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -16,8 +16,6 @@
 
 import logging
 import pathlib
-import shlex
-import subprocess
 from typing import Dict
 from urllib import request
 
@@ -25,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 ETCD = "etcd-v3.5.0-linux-amd64.tar.gz"
 ETCD_URL = f"https://github.com/etcd-io/etcd/releases/download/v3.5.0/{ETCD}"
+
 
 def get_slurmctld_res() -> Dict[str, pathlib.Path]:
     """Get slurmctld resources needed for charm deployment."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -22,7 +22,7 @@ from typing import Any, Coroutine
 
 import pytest
 import tenacity
-from helpers import get_slurmctld_res, get_slurmdbd_res
+from helpers import get_slurmctld_res
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -42,7 +42,6 @@ async def test_build_and_deploy_against_edge(
     """Test that the slurmdbd charm can stabilize against slurmctld and MySQL."""
     logger.info(f"Deploying {SLURMDBD} against {SLURMCTLD} and {DATABASE}")
     slurmctld_res = get_slurmctld_res()
-    get_slurmdbd_res()
     await asyncio.gather(
         ops_test.model.deploy(
             str(await slurmdbd_charm),


### PR DESCRIPTION
## Description

This pull request modifies _charmcraft.yaml_ so that the _version_ file is automatically generated when packing the slurmdbd operator with `charmcraft pack ...`

## How was the code tested?

Tested locally on my Ubuntu 22.04 LTS workstation by packing the slurmdbd charm and then examining the archive to ensure that the _version_ file was successfully generated. The integration tests will likely fail for the time being due to issues identified in https://github.com/omnivector-solutions/slurmdbd-operator/pull/15

## Related issues and/or tasks

See [Ubuntu HPC Matrix charming discussion](https://matrix.to/#/!ZbfygnnFzRUCtDyBYH:matrix.org/$yYv7YyHLQTYiCWQi67FLGAANIkOsTqpqEbPCxfOABvQ?via=matrix.org&via=projectsegfau.lt)

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
